### PR TITLE
implementation of ci_teardown job

### DIFF
--- a/.github/workflows/ci_teardown.yml
+++ b/.github/workflows/ci_teardown.yml
@@ -45,12 +45,12 @@ jobs:
       with:
         project_id: ${{ secrets.DBT_ENV_SECRET_PROJECT_ID }}
 
-    - name: Get Schema ID
+    - name: Get PR NUM
       id: schema_id
-      run: echo "SCHEMA_ID=${{ github.event.pull_request.number }}__${{ github.sha }}" >> $GITHUB_ENV
+      run: echo "PR_NUM=${{ github.event.number }}" >> $GITHUB_ENV
 
     - name: dbt deps
       run: dbt deps
 
     - name: drop PR schemas
-      run: dbt run-operation drop_pr_staging_schemas --args "{'SCHEMA_ID'":" '${SCHEMA_ID}' }" --profiles-dir ./
+      run: dbt run-operation drop_pr_staging_schemas --args "{'PR_number'":" '${PR_NUM}' }" --profiles-dir ./

--- a/.github/workflows/ci_teardown.yml
+++ b/.github/workflows/ci_teardown.yml
@@ -1,0 +1,56 @@
+name: CI schema teardown on PR close
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  CI_TEARDOWN_job:
+    runs-on: ubuntu-latest
+
+    env:
+      GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+      GCLOUD_STORAGE_PATH_MANIFEST: ${{ secrets.GCLOUD_STORAGE_PATH_MANIFEST }}
+      DBT_ENV_SECRET_TYPE: ${{ secrets.DBT_ENV_SECRET_TYPE }} 
+      DBT_ENV_SECRET_PROJECT_ID: ${{ secrets.DBT_ENV_SECRET_PROJECT_ID }}
+      DBT_ENV_SECRET_PRIVATE_KEY_ID: ${{ secrets.DBT_ENV_SECRET_PRIVATE_KEY_ID }} 
+      DBT_ENV_SECRET_PRIVATE_KEY: ${{ secrets.DBT_ENV_SECRET_PRIVATE_KEY }}  
+      DBT_ENV_SECRET_CLIENT_EMAIL: ${{ secrets.DBT_ENV_SECRET_CLIENT_EMAIL }}
+      DBT_ENV_SECRET_CLIENT_ID: ${{ secrets.DBT_ENV_SECRET_CLIENT_ID }} 
+      DBT_ENV_SECRET_AUTH_URI: ${{ secrets.DBT_ENV_SECRET_AUTH_URI }}
+      DBT_ENV_SECRET_TOKEN_URI: ${{ secrets.DBT_ENV_SECRET_TOKEN_URI }}
+      DBT_ENV_SECRET_AUTH_PROVIDER_X509_CERT_URL: ${{ secrets.DBT_ENV_SECRET_AUTH_PROVIDER_X509_CERT_URL }} 
+      DBT_ENV_SECRET_CLIENT_X509_CERT_URL: ${{ secrets.DBT_ENV_SECRET_CLIENT_X509_CERT_URL }} 
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: pip install -r dbt-requirements.txt
+
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v0.4.3
+      with:
+        credentials_json: ${{ secrets.GCLOUD_SERVICE_KEY }}
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v1
+      with:
+        project_id: ${{ secrets.DBT_ENV_SECRET_PROJECT_ID }}
+
+    - name: Get Schema ID
+      id: schema_id
+      run: echo "SCHEMA_ID=${{ github.event.pull_request.number }}__${{ github.sha }}" >> $GITHUB_ENV
+
+    - name: dbt deps
+      run: dbt deps
+
+    - name: drop PR schemas
+      run: dbt run-operation drop_pr_staging_schemas --args "{'SCHEMA_ID'":" '${SCHEMA_ID}' }" --profiles-dir ./

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -42,5 +42,3 @@ data_tests:
 seeds:
   dbt_project_evaluator:
     +enabled: "{{ env_var('ENABLE_DBT_PROJECT_EVALUATOR', 'false') | lower == 'true' | as_bool }}"
-
-on-run-end: "{% if target.name == 'pr' %} drop schema {{ target.schema }} cascade {% endif %}"

--- a/macros/drop_pr_staging_schemas.sql
+++ b/macros/drop_pr_staging_schemas.sql
@@ -5,7 +5,7 @@
             select schema_name
             from information_schema.schemata
             where
-            schema_name like 'pr_'||{{ PR_number }}||'%'
+            schema_name like 'pr_'||{{ PR_number }}||'__%'
         )
 
         select 

--- a/macros/drop_pr_staging_schemas.sql
+++ b/macros/drop_pr_staging_schemas.sql
@@ -1,0 +1,29 @@
+{%- macro drop_pr_staging_schemas(SCHEMA_ID) %}
+
+    {% set pr_cleanup_query %}
+        with pr_staging_schemas as (
+            select schema_name
+            from information_schema.schemata
+            where
+            schema_name like 'pr_'||{{ SCHEMA_ID }}||'%'
+        )
+
+        select 
+            'drop schema '||schema_name||';' as drop_command 
+        from pr_staging_schemas
+    {% endset %}
+
+{% do log(pr_cleanup_query, info=TRUE) %}
+
+{% set drop_commands = run_query(pr_cleanup_query).columns[0].values() %}
+
+{% if drop_commands %}
+  {% for drop_command in drop_commands %}
+    {% do log(drop_command, True) %}
+      {% do run_query(drop_command) %}
+  {% endfor %}
+{% else %}
+  {% do log('No schemas to drop.', True) %}
+{% endif %}
+
+{%- endmacro -%}

--- a/macros/drop_pr_staging_schemas.sql
+++ b/macros/drop_pr_staging_schemas.sql
@@ -1,11 +1,11 @@
-{%- macro drop_pr_staging_schemas(SCHEMA_ID) %}
+{%- macro drop_pr_staging_schemas(PR_number) %}
 
     {% set pr_cleanup_query %}
         with pr_staging_schemas as (
             select schema_name
             from information_schema.schemata
             where
-            schema_name like 'pr_'||{{ SCHEMA_ID }}||'%'
+            schema_name like 'pr_'||{{ PR_number }}||'%'
         )
 
         select 


### PR DESCRIPTION
`ci_teardown.yml` removes PR schemas once PRs are merged or closed. That way, the data continues to exist and is available for the developer to explore/investigate what is built using the code in the PR branch; and then is automatically cleaned up once no longer relevant.

@bruno-de-lima-phdata I figured it would be easier to show you in this PR, so you can decide if you want to include it in the project.

Interested in your thoughts!