### PR TITLE
fix: delete the schema when it still has data

### DIFF
--- a/macros/drop_pr_staging_schemas.sql
+++ b/macros/drop_pr_staging_schemas.sql
@@ -9,7 +9,7 @@
         )
 
         select 
-            'drop schema if exists '||schema_name||';' as drop_command 
+            'drop schema if exists '||schema_name||' cascade;' as drop_command 
         from pr_staging_schemas
     {% endset %}
 


### PR DESCRIPTION
https://cloud.google.com/bigquery/docs/managing-datasets?hl=en#delete-datasets

By default, this only works to delete an empty dataset. To delete a dataset and all of its contents, use the CASCADE keyword:

DROP SCHEMA IF EXISTS mydataset CASCADE;